### PR TITLE
Update IUnit.java

### DIFF
--- a/ITC515_assignment2/src/datamanagement/IUnit.java
+++ b/ITC515_assignment2/src/datamanagement/IUnit.java
@@ -1,34 +1,81 @@
 package datamanagement;
+public interface IUnit
+{
+  public String getUnitCode();
 
-public interface IUnit {
 
-    public String getUnitCode();
-    public String getUnitName();
 
-    public float getPsCutoff();
-    public void  setPsCutoff1(float cutoff);
+  public String getUnitName();
 
-    public float getCrCutoff();
-    public void  setCrCutoff(float cutoff);
 
-    public float getDiCuttoff();    
-    public void  setDiCutoff(float cutoff);
 
-    public float getHdCutoff();
-    public void  setHdCutoff(float cutoff);    
+  public float getPassCutoff();	
 
-    public float getAeCutoff();    
-    public void  setAeCutoff(float cutoff);
-    
-    public int getAsg1Weight();
-    public int getAsg2Weight();
-    public int getExamWeight();
-    public void setAssessmentWeights(int asg1Wgt, int asg2Wgt, int examWgt);
 
-    public String getGrade(float asg1, float asg2, float exam);
 
-    public void addStudentRecord(IStudentUnitRecord record );
-    public IStudentUnitRecord getStudentRecord(int studentID );
-    
-    public StudentUnitRecordList listStudentRecords();
+  public void setPassCutoff(float cutoff);
+
+
+
+  public float getCreditCutoff();
+
+
+
+  public void setCreditCutoff(float cutoff);
+
+
+
+  public float getDistinctionCuttoff();
+
+
+
+  public void setDistinctionCutoff(float cutoff);
+
+
+
+  public float getHighDistinctionCutoff();
+
+
+
+  public void setHighDistinctionCutoff(float cutoff);
+
+
+
+  public float getAeCutoff();
+
+
+
+  public void setAeCutoff(float cutoff);
+
+
+
+  public int getAssignment1Weight();
+
+
+
+  public int getAssignment2Weight();
+
+
+
+  public int getExamWeight();
+
+
+
+  public void setAssessmentWeights(int assignmentGrade1Weight, int assignmentGrade2Weight, int examWeigt);
+
+
+
+  public String getGrade(float assignmentGrade1, float assignmentGrade2, float exam);
+
+
+
+  public void addStudentRecord(IStudentUnitRecord record);
+
+
+
+  public IStudentUnitRecord getStudentRecord(int studentID);
+
+
+
+  public StudentUnitRecordList listStudentRecords();
 }


### PR DESCRIPTION
Introduce space between methods ,  shorten form of method name not clear for developer , As a result detail Method name for developer understand the methods.

Example:-  

Previously code structure :- 
    public String getUnitCode();  
    public String getUnitName();

After changing the structure :-

```
public String getUnitCode();

public String getUnitName();
```

Unclear method name :-

```
public float getPsCutoff();
public void  setPsCutoff1(float cutoff);
```

After altering the method name more understandable :-

```
public float getPassCutoff();

public void  setPassCutoff1(float cutoff);
```

Like wise the changes are made to all the method in the IUnit.java.  Based on the Java Standard 

Generic variables should have the same name as their type :-

publi void setTopic(Topic topic) // NOT: void setTopic(Topic value)
                                                // NOT: void setTopic(Topic aTopic)
                                                // NOT: void setTopic(Topic t)
                                                // NOT: public float getPsCutoff();
                                                // NOT: public void  setPsCutoff1(float cutoff);

void connect(Database database) // NOT: void connect(Database db)
                                                   // NOT: void connect(Database oracleDB)
Reduce complexity by reducing the number of terms and names used. Also makes it easy to deduce the type given a variable name only.

If for some reason this convention doesn't seem to fit it is a strong indication that the type name is badly chosen.

Non-generic variables have a role. These variables can often be named by combining role and type:

  Point  startingPoint, centerPoint;
  Name   loginName;
